### PR TITLE
fix: comment out unused formatPrice function to resolve TypeScript error

### DIFF
--- a/src/components/TradeFlow.vue
+++ b/src/components/TradeFlow.vue
@@ -59,13 +59,13 @@ const matchingOrders = computed(() => {
     });
 });
 
-function formatPrice(price: string): string {
+/* function formatPrice(price: string): string {
   const num = parseFloat(price);
   return isNaN(num) ? '0.00' : num.toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2
   });
-}
+} */
 
 function formatAmount(amount: string): string {
   const num = parseFloat(amount);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed an unused routine for formatting price values. All visible behaviors and the formatting functionality still in use remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->